### PR TITLE
resolve login issue

### DIFF
--- a/strava/api/oauth2.py
+++ b/strava/api/oauth2.py
@@ -61,4 +61,4 @@ class OAuth2AuthorizationCodeFlow(object):
 
     def get_access_token(self, code):
         return self.client.fetch_token(self.token_url, code=code, client_id=self.client_id,
-                                       client_secret=self.client_secret)
+                                       client_secret=self.client_secret, include_client_id=True)


### PR DESCRIPTION
issue manifests during 'strava login' as -
 oauthlib.oauth2.rfc6749.errors.MissingTokenError: (missing_token) Missing access token parameter.

the underlying message from the server is the error -
 {'message': 'Bad Request', 'errors': [{'resource': 'Application', 'field': 'client_id', 'code': 'invalid'}]}

the root cause appears to be that the client_id is not included in the access token request.

reproduced with requests==2.22.0, requests-oauthlib==1.3.0, oauthlib==3.1.0