### PR TITLE
Add bulk upload (for migration from competing services)

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,18 @@ Combine JSON output with `jq`:
 ➜ strava activities -pp 1 -q | xargs strava activity --output json | jq ".name"
 "Afternoon Run"
 ```
+
+Upload Activity from GPX (example: export from a competing service):
+```sh
+strava upload ./2020-09-27-145141.gpx
+```
+```console
+Id:      4717164254
+Status:  Your activity is still being processed.
+Error:   None
+```
+
+Can upload multiple activities.
+```sh
+strava upload ./*.gpx
+```

--- a/strava/api/__init__.py
+++ b/strava/api/__init__.py
@@ -1,2 +1,3 @@
 from .activity import get_activity
+from .upload import post_upload
 from .athlete import get_activities, get_stats, get_athlete

--- a/strava/api/__init__.py
+++ b/strava/api/__init__.py
@@ -1,3 +1,3 @@
 from .activity import get_activity
-from .upload import post_upload
+from .upload import post_upload, get_upload
 from .athlete import get_activities, get_stats, get_athlete

--- a/strava/api/upload.py
+++ b/strava/api/upload.py
@@ -1,6 +1,16 @@
 from ._helpers import client, url, json
 
 
-def post_upload(xargs):
-    response = client.post(url(f'/uploads'), data=xargs)
+def post_upload(xargs, filename):
+    response=None
+    #with open(filename, 'rb') as f:
+    files={"file": open(filename, 'rb')}
+    response = client.post(url=url(f'/uploads'), data=xargs, files=files)
+    try:
+        return json(response)
+    except:
+        return response
+
+def get_upload(upload_id):
+    response = client.get(url(f'/uploads/{upload_id}'))
     return json(response)

--- a/strava/api/upload.py
+++ b/strava/api/upload.py
@@ -1,0 +1,6 @@
+from ._helpers import client, url, json
+
+
+def post_upload(xargs):
+    response = client.post(url(f'/uploads'), data=xargs)
+    return json(response)

--- a/strava/cli.py
+++ b/strava/cli.py
@@ -16,6 +16,7 @@ cli.add_command(get_activity)
 cli.add_command(get_profile)
 cli.add_command(get_stats)
 cli.add_command(set_config)
+cli.add_command(upload)
 
 if __name__ == '__main__':
     cli()

--- a/strava/cli.py
+++ b/strava/cli.py
@@ -1,6 +1,6 @@
 import click
 
-from strava.commands import login, logout, get_activities, get_activity, get_profile, get_stats, set_config
+from strava.commands import login, logout, get_activities, get_activity, get_profile, get_stats, set_config, post_upload
 
 
 @click.group()

--- a/strava/cli.py
+++ b/strava/cli.py
@@ -16,7 +16,7 @@ cli.add_command(get_activity)
 cli.add_command(get_profile)
 cli.add_command(get_stats)
 cli.add_command(set_config)
-cli.add_command(upload)
+cli.add_command(post_upload)
 
 if __name__ == '__main__':
     cli()

--- a/strava/commands/__init__.py
+++ b/strava/commands/__init__.py
@@ -1,5 +1,6 @@
 from .activities import get_activities
 from .activity import get_activity
+from .upload import post_upload
 from .config import set_config
 from .login import login
 from .logout import logout

--- a/strava/commands/upload.py
+++ b/strava/commands/upload.py
@@ -37,13 +37,13 @@ def _format_upload(result, output=None):
 
 def _as_table(upload_result):
     def format_id(upload_id):
-        return "{0}".format(upload_id)
+        return f'{upload_id}'
 
     def format_error(upload_error):
-        return "{0}".format(upload_error)
+        return f'{upload_error}'
 
     def format_status(upload_status):
-        return "{0}".format(upload_status)
+        return f'{upload_status}'
 
     def format_property(name):
                 return click.style(f'{humanize(name)}:', bold=True)

--- a/strava/commands/upload.py
+++ b/strava/commands/upload.py
@@ -18,6 +18,15 @@ def post_upload(output, upload_files):
     for i, filename in enumerate(upload_files):
         if i > 0:
             click.echo()
+        if i % 90 == 0 and i > 5:
+            import time
+            click.echo(f'Sleeping for API rate limiting, uploaded {i} items.')
+            time.sleep(900)
+            # Can only perform 100 API requests every 15 minutes
+            # so we'll do 90 then sleep, to allow for reads that may happen in other threads
+            # http://developers.strava.com/docs/#rate-limiting
+            # the api/upload/py post_upload() code *should* catch this, sleep, and retry itself
+            # but the included requests module isn't returning the error code to trap the 429.
         xargs = _process_file(filename)
         if xargs is None:
             # file isn't XML, have to bail

--- a/strava/commands/upload.py
+++ b/strava/commands/upload.py
@@ -1,0 +1,83 @@
+import os
+
+import click
+
+from strava import api, emoji
+from strava.decorators import output_option, login_required, format_result, TableFormat, OutputType
+from strava.formatters import humanize, noop_formatter, \
+    format_date, format_seconds, apply_formatters
+
+_ACTIVITY_COLUMNS = ('key', 'value')
+
+
+@click.command('upload')
+@click.argument('upload_files', required=True, nargs=-1)
+@output_option()
+@login_required
+def post_upload(output, upload_files):
+    for i, filename in enumerate(upload_files):
+        if i > 0:
+            click.echo()
+        xargs = _process_file(filename)
+        if xargs is None:
+            # file isn't XML, have to bail
+            result = None
+        else:
+            result=None
+            with open(filename, 'rb') as f:
+                xargs.update({'file':f})
+                result = api.post_upload(xargs)
+        _format_upload(result, output=output)
+
+
+@format_result(table_columns=_ACTIVITY_COLUMNS, show_table_headers=False, table_format=TableFormat.PLAIN)
+def _format_upload(result, output=None):
+    return result if output == OutputType.JSON.value else _as_table(result)
+
+
+def _as_table(upload_result):
+    def format_id(upload_id):
+        return "{0}".format(upload_id)
+
+
+    formatters = {
+        'id': format_id,
+        'status': noop_formatter,
+        'error': noop_formatter,
+    }
+
+    basic_data = [
+        {'key': format_property(k), 'value': v} for k, v in apply_formatters(activity, formatters).items()
+    ]
+    split_data = [
+        {'key': format_property(f"Split {split.get('split')}"), 'value': format_split(split)} for split in
+        activity.get('splits_metric', [])
+    ]
+
+    return [
+        *basic_data,
+        *split_data
+    ]
+
+def _process_file(filename):
+    import xml.etree.ElementTree as ET
+    import re
+    try:
+        activity_tree = ET.parse(filename)
+        activity_root = activity_tree.getroot()
+    except xml.etree.ElementTree.ParseError:
+        # not an XML file - there might be junk in the directory
+        return None
+    params={}
+    typere=re.search(r'\}([a-z.]{3,6})$', root.tag)
+    if typere:
+        params.update({'data_type': typere.group(1)})
+    try:
+        if re.search(r'\}name$', root[0][0].tag):
+            params.update({'name': root[0][0].text})
+    except IndexError:
+        # This tag doesn't exist, it's not RunKeeper format GPX
+        # so some other format defines the definition. TODO
+        ...
+    return params
+

--- a/strava/settings.py
+++ b/strava/settings.py
@@ -10,7 +10,7 @@ STRAVA_CLIENT_SECRET = os.getenv('STRAVA_CLIENT_SECRET') or cfg.get('client_secr
 STRAVA_AUTH_API_BASE_URL = 'https://www.strava.com/oauth'
 STRAVA_API_BASE_URL = 'https://www.strava.com/api/v3'
 
-CLIENT_SCOPE = ['activity:read_all']
+CLIENT_SCOPE = ['activity:read_all,activity:write']
 AUTH_URL = f'{STRAVA_AUTH_API_BASE_URL}/authorize'
 TOKEN_URL = f'{STRAVA_AUTH_API_BASE_URL}/token'
 REFRESH_TOKEN_URL = TOKEN_URL


### PR DESCRIPTION
Update the CLI app rights to include Activity:write.  Add function for uploading activities. Tested via GPX, others from documentation should work, but the XML parser may fail. I don't have any other data to test against, but tried to make it resilient, since the API supports many file types.

Because of app rate limiting, I had to put a 15 minute sleep in the code after 90 items (rather than 100, explained in comments).

I tried to catch this in the "api/upload.py" rather than commands/upload.py", except I ran into this:
except HTTPError as e:
  if e.code == 429:

But e doesn't have a "code" or "reason" attribute as the urllib and requests documents explain. I'm not sure what the problem is there, but when we CAN capture that error, we should move the rate limiting to the API code.