### PR TITLE
Fixed speed formatting for different activity types

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
 select = BLK,C,E,F,W
 ignore = E203,W503
-max-line-length = 88
+max-line-length = 119

--- a/strava/commands/activities.py
+++ b/strava/commands/activities.py
@@ -64,7 +64,7 @@ def _as_table(result):
 
 
 def _format_summary_activity(activity):
-    def format_name(name):
+    def format_name(name, activity):
         return format_activity_name(name, activity)
 
     formatters = {"name": format_name, **_SUMMARY_ACTIVITY_FORMATTERS}

--- a/strava/commands/activity.py
+++ b/strava/commands/activity.py
@@ -53,7 +53,7 @@ def _format_activity(result, output=None):
 
 
 def _as_table(activity):
-    def format_name(name):
+    def format_name(name, activity = None):
         activity_name = format_activity_name(name, activity)
         activity_description = activity.get("description")
         return (
@@ -69,7 +69,7 @@ def _as_table(activity):
         return f"{click.style(emoji.RED_HEART, fg='red')} {format_heartrate(heartrate)}"
 
     def format_speed_with_emoji(speed):
-        return f"{click.style(emoji.RUNNING_SHOE, fg='yellow')} {format_speed(speed)}"
+        return f"{click.style(emoji.RUNNING_SHOE, fg='yellow')} {format_speed(speed, activity)}"
 
     def format_elevation_with_emoji(elevation):
         difference = round(elevation)

--- a/strava/commands/activity.py
+++ b/strava/commands/activity.py
@@ -53,7 +53,7 @@ def _format_activity(result, output=None):
 
 
 def _as_table(activity):
-    def format_name(name, activity = None):
+    def format_name(name, activity=None):
         activity_name = format_activity_name(name, activity)
         activity_description = activity.get("description")
         return (

--- a/strava/formatters.py
+++ b/strava/formatters.py
@@ -11,7 +11,7 @@ N_A = "N/A"
 KM_TO_MI = 0.6213712
 
 
-def format_seconds(seconds):
+def format_seconds(seconds, activity = None):
     if seconds > 3600:
         mins = math.floor(seconds / 60)
         return f"{math.floor(mins / 60):.0f}h {mins % 60:.0f}m"
@@ -19,12 +19,12 @@ def format_seconds(seconds):
         return f"{math.floor(seconds / 60):02.0f}:{seconds % 60:02.0f}"
 
 
-def format_date(date):
+def format_date(date, activity = None):
     utc_date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return utc_date.replace(tzinfo=timezone.utc).astimezone()
 
 
-def format_distance(distance):
+def format_distance(distance, activity = None):
     distance = math.floor(distance / 10) / 100
     suffix = "km"
     if strava.settings.IMPERIAL_UNITS:
@@ -33,20 +33,31 @@ def format_distance(distance):
     return f"{distance:.2f} {suffix}"
 
 
-def format_speed(speed):
+def format_speed(speed, activity):
+    activity_types_with_speed = [
+        "alpineski", "backcountryski", "ebikeride", "handcycle",
+        "nordicski", "ride", "rollerski", "skateboard", "snowboard",
+        "virtualride"
+    ]
+
     suffix = "km"
+    postfix = "kph"
     if strava.settings.IMPERIAL_UNITS:
         suffix = "mi"
+        postfix = "mph"
         speed = speed * KM_TO_MI
 
-    return f"{format_seconds(1000 / speed)} /{suffix}" if speed > 0 else None
+    if activity.get("type").lower() in activity_types_with_speed:
+        return f"{speed * 3.6:.1f} {postfix}" if speed > 0 else None
+    else:
+        return f"{format_seconds(1000 / speed, activity)} /{suffix}" if speed > 0 else None
 
 
-def format_heartrate(heartrate):
+def format_heartrate(heartrate, activity = None):
     return f"{heartrate:.0f} bpm"
 
 
-def format_activity_type(activity_type):
+def format_activity_type(activity_type, activity = None):
     type_emojis = {
         "run": emoji.PERSON_RUNNING,
         "walk": emoji.PERSON_WALKING,
@@ -57,7 +68,7 @@ def format_activity_type(activity_type):
     return type_emojis.get(activity_type.lower(), "")
 
 
-def format_elevation(elevation):
+def format_elevation(elevation, activity = None):
     return f"{round(elevation)} m"
 
 
@@ -68,11 +79,11 @@ def humanize(word):
     return word
 
 
-def noop_formatter(value):
+def noop_formatter(value, activity = None):
     return value
 
 
-def format_activity_name(name, activity):
+def format_activity_name(name, activity = None):
     activity_type = format_activity_type(activity.get("type"))
     is_race = activity.get("workout_type", 0) == 1
     return f"{activity_type} {click.style(name, bold=is_race)}"
@@ -80,6 +91,6 @@ def format_activity_name(name, activity):
 
 def apply_formatters(activity, formatters):
     return {
-        k: formatter(activity[k]) if k in activity else N_A
+        k: formatter(activity[k], activity) if k in activity else N_A
         for k, formatter in formatters.items()
     }

--- a/strava/formatters.py
+++ b/strava/formatters.py
@@ -11,7 +11,7 @@ N_A = "N/A"
 KM_TO_MI = 0.6213712
 
 
-def format_seconds(seconds, activity = None):
+def format_seconds(seconds, activity=None):
     if seconds > 3600:
         mins = math.floor(seconds / 60)
         return f"{math.floor(mins / 60):.0f}h {mins % 60:.0f}m"
@@ -19,12 +19,12 @@ def format_seconds(seconds, activity = None):
         return f"{math.floor(seconds / 60):02.0f}:{seconds % 60:02.0f}"
 
 
-def format_date(date, activity = None):
+def format_date(date, activity=None):
     utc_date = datetime.strptime(date, "%Y-%m-%dT%H:%M:%SZ")
     return utc_date.replace(tzinfo=timezone.utc).astimezone()
 
 
-def format_distance(distance, activity = None):
+def format_distance(distance, activity=None):
     distance = math.floor(distance / 10) / 100
     suffix = "km"
     if strava.settings.IMPERIAL_UNITS:
@@ -35,9 +35,16 @@ def format_distance(distance, activity = None):
 
 def format_speed(speed, activity):
     activity_types_with_speed = [
-        "alpineski", "backcountryski", "ebikeride", "handcycle",
-        "nordicski", "ride", "rollerski", "skateboard", "snowboard",
-        "virtualride"
+        "alpineski",
+        "backcountryski",
+        "ebikeride",
+        "handcycle",
+        "nordicski",
+        "ride",
+        "rollerski",
+        "skateboard",
+        "snowboard",
+        "virtualride",
     ]
 
     suffix = "km"
@@ -50,14 +57,16 @@ def format_speed(speed, activity):
     if activity.get("type").lower() in activity_types_with_speed:
         return f"{speed * 3.6:.1f} {postfix}" if speed > 0 else None
     else:
-        return f"{format_seconds(1000 / speed, activity)} /{suffix}" if speed > 0 else None
+        return (
+            f"{format_seconds(1000 / speed, activity)} /{suffix}" if speed > 0 else None
+        )
 
 
-def format_heartrate(heartrate, activity = None):
+def format_heartrate(heartrate, activity=None):
     return f"{heartrate:.0f} bpm"
 
 
-def format_activity_type(activity_type, activity = None):
+def format_activity_type(activity_type, activity=None):
     type_emojis = {
         "run": emoji.PERSON_RUNNING,
         "walk": emoji.PERSON_WALKING,
@@ -68,7 +77,7 @@ def format_activity_type(activity_type, activity = None):
     return type_emojis.get(activity_type.lower(), "")
 
 
-def format_elevation(elevation, activity = None):
+def format_elevation(elevation, activity=None):
     return f"{round(elevation)} m"
 
 
@@ -79,11 +88,11 @@ def humanize(word):
     return word
 
 
-def noop_formatter(value, activity = None):
+def noop_formatter(value, activity=None):
     return value
 
 
-def format_activity_name(name, activity = None):
+def format_activity_name(name, activity=None):
     activity_type = format_activity_type(activity.get("type"))
     is_race = activity.get("workout_type", 0) == 1
     return f"{activity_type} {click.style(name, bold=is_race)}"


### PR DESCRIPTION
Fixes #21 by:

* Passing the activity object as context to most formatter functions (optional, set to `None` by default on functions that don't need it 
* Modifying `format_speed` to show the speed in kph/mph on activities where I know it's shown like that in Strava 

Tested to work on both the `activities` (table listing) command and on the single `activity` command.

Caveats:

*  I don't have a definitive list of activities where Strava shows speed as kph / mph instead of pace. There might be others I've missed